### PR TITLE
CSS Fixes

### DIFF
--- a/frontend/src/components/DocumentClass.js
+++ b/frontend/src/components/DocumentClass.js
@@ -206,8 +206,7 @@ export class DocumentClass extends Component {
               <span>{text.description}</span>
               <Input
                 type="textarea"
-                className="textarea-input"
-                style={{ height: '200px' }}
+                className="textarea-input textarea-height"
                 onChange={this.updateDescription}
                 value={this.state.description}
               />

--- a/frontend/src/components/DocumentClassPage.js
+++ b/frontend/src/components/DocumentClassPage.js
@@ -179,8 +179,7 @@ export class DocumentClassPage extends Component {
               <span>{text.description}</span>
               <Input
                 type="textarea"
-                className="textarea-input"
-                style={{ height: '200px' }}
+                className="textarea-input textarea-height"
                 onChange={this.updateDescription}
               />
               <br />

--- a/frontend/src/components/DocumentClassPreview.js
+++ b/frontend/src/components/DocumentClassPreview.js
@@ -52,11 +52,6 @@ export class DocumentClassPreview extends Component {
   }
 
   render() {
-    const customStyles = {
-      height: '500px',
-      width: '500px',
-      overflow: 'scroll'
-    }
     const externalCloseBtn = (
       <button
         className="close"
@@ -79,7 +74,7 @@ export class DocumentClassPreview extends Component {
 
         <Modal isOpen={this.state.modal} toggle={this.toggle} external={externalCloseBtn}>
           <ModalHeader>{this.props.documentClass.name}</ModalHeader>
-          <ModalBody style={customStyles}>
+          <ModalBody className="docclass-modalbody">
             <p>{this.props.documentClass.description}</p>
             <Iframe
               url={this.props.documentClass.example}

--- a/frontend/src/components/DocumentListItem.js
+++ b/frontend/src/components/DocumentListItem.js
@@ -189,7 +189,7 @@ export class DocumentListItem extends Component {
           external={externalCloseBtn}
         >
           <ModalHeader>{this.props.document.docClass.name}</ModalHeader>
-          <ModalBody style={customStyles}>
+          <ModalBody className="docclass-modalbody">
             <p>{this.props.document.docClass.description}</p>
             <Iframe
               url={this.props.document.docClass.example}

--- a/frontend/src/components/Load.js
+++ b/frontend/src/components/Load.js
@@ -38,7 +38,10 @@ class Load extends Component {
 
     if (this.props.loading) {
       return (
-        <div className="load" style={{ paddingTop: '15%' }}>
+        <div
+          className="load"
+          style={{ position: 'fixed', top: 0, bottom: 0, left: 0, right: 0, paddingTop: '15%' }}
+        >
           <h1>{text.loading}</h1>
           <Loader type="Puff" color="#4FAF4E" height="10%" width="10%" />
         </div>

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -115,3 +115,14 @@ html, body {
 .modal-input-master {
   width: 100%;
 }
+
+.modal-body .textarea-height {
+  /* textarea inputs in modals */
+  height: 200px;
+}
+
+.docclass-modalbody {
+  height: 500px;
+  width: 500px;
+  overflow: scroll;
+}

--- a/frontend/src/tests/__snapshots__/DocumentClass.test.js.snap
+++ b/frontend/src/tests/__snapshots__/DocumentClass.test.js.snap
@@ -43,13 +43,8 @@ exports[`DocumentClass renders correctly 1`] = `
           Description:
         </span>
         <Input
-          className="textarea-input"
+          className="textarea-input textarea-height"
           onChange={[Function]}
-          style={
-            Object {
-              "height": "200px",
-            }
-          }
           type="textarea"
           value="testingaswell"
         />

--- a/frontend/src/tests/__snapshots__/DocumentListItem.test.js.snap
+++ b/frontend/src/tests/__snapshots__/DocumentListItem.test.js.snap
@@ -98,13 +98,7 @@ exports[`DocumentListItem renders correctly 1`] = `
       wrapTag="div"
     />
     <ModalBody
-      style={
-        Object {
-          "height": "500px",
-          "overflow": "scroll",
-          "width": "500px",
-        }
-      }
+      className="docclass-modalbody"
       tag="div"
     >
       <p />


### PR DESCRIPTION
Resolves #

Fixes some CSS styling issues in the app; namely, it makes it such that the loading screen takes up the entire page rather than a portion. You can still scroll while the loading is there, but the loading will always show instead of only taking up half the screen. Also added some classes for some reused inline styling for some components.