### PR TITLE
Fix PM creation

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, request, json
 from api.models import DocumentClass, db
 from api.core import create_response, serialize_list, logger
-from uuid import uuid4
 
 import requests, json, random, string
 


### PR DESCRIPTION
Registering a PM currently uses the name `Daniel`, and since each PM has a correspondingly named folder in Box, registerig multiple PMs results in name collision Box errors.

This PR instead assigns a random `uuid` to the PM name to avoid name collisions.